### PR TITLE
Add diagnostic logging via log/env_logger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,4 +19,5 @@ build-system marker files to avoid false positives, then optionally deletes them
 - Output functions take `&mut dyn Write` for testability
 - `thiserror` for error types
 - `clap` derive for CLI
+- `log` facade for diagnostics (`info!` for pipeline stages, `debug!` for granular detail, `warn!` for recoverable errors); `env_logger` backend initialized in `main.rs`
 - Integration tests use `tempfile` + `assert_cmd`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,8 +157,10 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "env_logger",
  "globset",
  "jwalk",
+ "log",
  "predicates",
  "rayon",
  "tempfile",
@@ -238,6 +240,29 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -354,6 +379,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +468,21 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "predicates"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ rust-version = "1.85"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+env_logger = "0.11"
 jwalk = "0.8"
+log = "0.4"
 rayon = "1"
 thiserror = "2"
 globset = "0.4"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ are included. Both flags are repeatable.
 clean-builds ~/Developer --verbose
 ```
 
-Shows individual artifact paths and sizes under each build system group.
+Shows individual artifact paths and sizes under each build system group, plus
+detailed diagnostic logging on stderr (artifact matches, filter decisions, per-artifact
+sizes). Without `--verbose`, only pipeline stage progress is logged to stderr.
 
 ## Supported Build Systems
 

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,6 +1,7 @@
 use std::io::{BufRead, Write};
 use std::path::Path;
 
+use log::{debug, info, warn};
 use rayon::prelude::*;
 
 use crate::scanner::Artifact;
@@ -46,9 +47,13 @@ pub fn confirm_and_delete(
         }
     }
 
+    info!("Deleting {} artifact directories", artifacts.len());
     let results: Vec<Result<(), DeleteError>> = artifacts
         .par_iter()
-        .map(|artifact| delete_artifact(&artifact.path))
+        .map(|artifact| {
+            debug!("Deleting {}", artifact.path.display());
+            delete_artifact(&artifact.path)
+        })
         .collect();
 
     let mut deleted = 0;
@@ -56,7 +61,10 @@ pub fn confirm_and_delete(
     for result in results {
         match result {
             Ok(()) => deleted += 1,
-            Err(e) => errors.push(e),
+            Err(e) => {
+                warn!("{e}");
+                errors.push(e);
+            }
         }
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -78,7 +78,12 @@ impl ArtifactFilter {
             .collect();
         let removed = before - filtered.len();
         if removed > 0 {
-            debug!("Filter: {} -> {} artifacts ({} removed)", before, filtered.len(), removed);
+            debug!(
+                "Filter: {} -> {} artifacts ({} removed)",
+                before,
+                filtered.len(),
+                removed
+            );
         }
         filtered
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use log::warn;
+
 /// Describes a build artifact directory and how to identify it.
 #[derive(Debug, Clone)]
 pub struct ArtifactRule {
@@ -210,6 +212,7 @@ pub fn has_marker(parent: &Path, marker: &MarkerKind) -> bool {
         MarkerKind::Files(names) => names.iter().any(|name| parent.join(name).exists()),
         MarkerKind::GlobSuffix(suffix) => {
             let Ok(entries) = std::fs::read_dir(parent) else {
+                warn!("Cannot read directory: {}", parent.display());
                 return false;
             };
             entries.filter_map(|e| e.ok()).any(|e| {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -43,7 +43,10 @@ pub fn scan(root: &Path) -> Vec<Artifact> {
 
                 let name = entry.file_name.to_string_lossy();
                 if name == ".git" {
-                    debug!("Skipping .git directory: {}", entry.parent_path.join(&entry.file_name).display());
+                    debug!(
+                        "Skipping .git directory: {}",
+                        entry.parent_path.join(&entry.file_name).display()
+                    );
                     entry.read_children_path = None;
                     continue;
                 }
@@ -55,7 +58,11 @@ pub fn scan(root: &Path) -> Vec<Artifact> {
                 };
 
                 if let Some(artifact) = try_match(&path, dir_name, &rules) {
-                    debug!("Found artifact: {} ({})", artifact.path.display(), artifact.build_system);
+                    debug!(
+                        "Found artifact: {} ({})",
+                        artifact.path.display(),
+                        artifact.build_system
+                    );
                     artifacts_ref.lock().unwrap().push(artifact);
                     entry.read_children_path = None;
                 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use jwalk::WalkDir;
+use log::debug;
 use rayon::prelude::*;
 
 use crate::scanner::Artifact;
@@ -11,6 +12,7 @@ pub fn compute_sizes(artifacts: &mut [Artifact]) {
 
     for (artifact, size) in artifacts.iter_mut().zip(sizes) {
         artifact.size_bytes = size;
+        debug!("{}: {}", artifact.path.display(), format_size(size));
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -256,3 +256,40 @@ fn pycache_detected_without_marker() {
         .success()
         .stdout(predicate::str::contains("Python"));
 }
+
+#[test]
+fn verbose_shows_debug_log_on_stderr() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--verbose")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Found artifact"));
+}
+
+#[test]
+fn default_shows_info_log_on_stderr() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Scanning"));
+}
+
+#[test]
+fn default_does_not_show_debug_log() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Found artifact").not());
+}


### PR DESCRIPTION
## Summary

- Add `log` facade + `env_logger` backend for structured diagnostic logging
- Pipeline stage progress (`info!`) logged by default; `--verbose` enables `debug!`-level detail (artifact matches, filter decisions, per-artifact sizes, deletion progress)
- `warn!` for recoverable errors (directory read failures, deletion errors)
- Three new integration tests verify logging behavior on stderr

Closes #5

## Test plan

- [x] `cargo test` -- all 82 tests pass (63 unit + 19 integration)
- [ ] `cargo run -- .` -- info-level messages on stderr
- [ ] `cargo run -- -v .` -- debug-level detail on stderr
- [ ] `cargo run -- -v --delete -y <test-dir>` -- deletion progress visible