### PR TITLE
Add --system and --exclude-system flags for build system filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Options:
   -v, --verbose         Show individual artifact paths
   --include <PATTERN>   Include only artifacts matching glob pattern (repeatable)
   --exclude <PATTERN>   Exclude artifacts matching glob pattern (repeatable)
+  --system <ID>         Include only these build systems (repeatable, see --list-systems)
+  --exclude-system <ID> Exclude these build systems (repeatable, see --list-systems)
+  --list-systems        List available build system IDs and exit
   -h, --help            Help
 ```
 
@@ -89,6 +92,43 @@ containing `/` are used as-is for explicit path control (e.g., `apps/*/target`).
 Exclude takes precedence over include. If no `--include` is specified, all artifacts
 are included. Both flags are repeatable.
 
+### Filtering by build system
+
+Filter by build system identity using `--system` and `--exclude-system`. These
+flags are mutually exclusive. Use `--list-systems` to see available IDs.
+
+Only clean Node.js artifacts:
+
+```sh
+clean-builds ~/Developer --system node
+```
+
+Clean everything except Python:
+
+```sh
+clean-builds ~/Developer --exclude-system python
+```
+
+Multiple systems can be specified:
+
+```sh
+clean-builds ~/Developer --system cargo --system node
+```
+
+Combine with glob filters for fine-grained control:
+
+```sh
+clean-builds ~/Developer --system node --exclude 'legacy-*'
+```
+
+List available system IDs:
+
+```sh
+clean-builds --list-systems
+```
+
+System IDs are matched case-insensitively.
+
 ### Verbose mode
 
 ```sh
@@ -103,22 +143,22 @@ sizes). Without `--verbose`, only pipeline stage progress is logged to stderr.
 
 Each artifact directory is only matched when a marker file exists in its parent directory to prevent false positives.
 
-| Build System | Artifact Dirs | Marker Files |
-|---|---|---|
-| Java/Maven | `target/` | `pom.xml` |
-| Rust/Cargo | `target/` | `Cargo.toml` |
-| Scala/SBT | `target/` | `build.sbt` |
-| Node.js | `node_modules/`, `.next/`, `.nuxt/`, `.output/` | `package.json` |
-| Swift/SPM | `.build/` | `Package.swift` |
-| Python | `__pycache__/` (no marker), `.venv/`, `venv/`, `.mypy_cache/` (no marker), `.pytest_cache/` (no marker), `.tox/`, `*.egg-info/` | `pyproject.toml` or `setup.py` or `requirements.txt` (where noted) |
-| Android/Gradle | `build/`, `.gradle/` | `build.gradle` or `build.gradle.kts` |
-| C/C++/CMake | `build/`, `CMakeFiles/` | `CMakeLists.txt` |
-| .NET/C# | `bin/`, `obj/` | `*.csproj` or `*.sln` |
-| Elixir/Mix | `_build/`, `deps/` | `mix.exs` |
-| Haskell/Stack | `.stack-work/` | `stack.yaml` |
-| Haskell/Cabal | `dist-newstyle/` | `*.cabal` |
-| Dart/Flutter | `.dart_tool/`, `build/` | `pubspec.yaml` |
-| Zig | `zig-out/`, `zig-cache/` | `build.zig` |
-| PHP/Composer | `vendor/` | `composer.json` |
-| CocoaPods | `Pods/` | `Podfile` |
-| Ruby/Bundler | `vendor/bundle/` | `Gemfile` |
+| ID | Build System | Artifact Dirs | Marker Files |
+|---|---|---|---|
+| `bundler` | Ruby/Bundler | `vendor/bundle/` | `Gemfile` |
+| `cabal` | Haskell/Cabal | `dist-newstyle/` | `*.cabal` |
+| `cargo` | Rust/Cargo | `target/` | `Cargo.toml` |
+| `cmake` | C/C++/CMake | `build/`, `CMakeFiles/` | `CMakeLists.txt` |
+| `cocoapods` | CocoaPods | `Pods/` | `Podfile` |
+| `composer` | PHP/Composer | `vendor/` | `composer.json` |
+| `dotnet` | .NET/C# | `bin/`, `obj/` | `*.csproj` or `*.sln` |
+| `flutter` | Dart/Flutter | `.dart_tool/`, `build/` | `pubspec.yaml` |
+| `gradle` | Android/Gradle | `build/`, `.gradle/` | `build.gradle` or `build.gradle.kts` |
+| `maven` | Java/Maven | `target/` | `pom.xml` |
+| `mix` | Elixir/Mix | `_build/`, `deps/` | `mix.exs` |
+| `node` | Node.js | `node_modules/`, `.next/`, `.nuxt/`, `.output/` | `package.json` |
+| `python` | Python | `__pycache__/` (no marker), `.venv/`, `venv/`, `.mypy_cache/` (no marker), `.pytest_cache/` (no marker), `.tox/`, `*.egg-info/` | `pyproject.toml` or `setup.py` or `requirements.txt` (where noted) |
+| `sbt` | Scala/SBT | `target/` | `build.sbt` |
+| `spm` | Swift/SPM | `.build/` | `Package.swift` |
+| `stack` | Haskell/Stack | `.stack-work/` | `stack.yaml` |
+| `zig` | Zig | `zig-out/`, `zig-cache/` | `build.zig` |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,18 @@ pub struct Cli {
     /// Exclude artifacts matching glob pattern (repeatable)
     #[arg(long, value_name = "PATTERN")]
     pub exclude: Vec<String>,
+
+    /// Include only these build systems (repeatable, see --list-systems)
+    #[arg(long, value_name = "ID", conflicts_with = "exclude_system")]
+    pub system: Vec<String>,
+
+    /// Exclude these build systems (repeatable, see --list-systems)
+    #[arg(long, value_name = "ID", conflicts_with = "system")]
+    pub exclude_system: Vec<String>,
+
+    /// List available build system IDs and exit
+    #[arg(long)]
+    pub list_systems: bool,
 }
 
 #[cfg(test)]
@@ -46,6 +58,9 @@ mod tests {
         assert!(!cli.verbose);
         assert!(cli.include.is_empty());
         assert!(cli.exclude.is_empty());
+        assert!(cli.system.is_empty());
+        assert!(cli.exclude_system.is_empty());
+        assert!(!cli.list_systems);
     }
 
     #[test]
@@ -90,5 +105,47 @@ mod tests {
     fn verbose_long_form() {
         let cli = Cli::parse_from(["clean-builds", "--verbose"]);
         assert!(cli.verbose);
+    }
+
+    #[test]
+    fn system_flag() {
+        let cli = Cli::parse_from([
+            "clean-builds",
+            "--system",
+            "cargo",
+            "--system",
+            "node",
+        ]);
+        assert_eq!(cli.system, vec!["cargo", "node"]);
+        assert!(cli.exclude_system.is_empty());
+    }
+
+    #[test]
+    fn exclude_system_flag() {
+        let cli = Cli::parse_from([
+            "clean-builds",
+            "--exclude-system",
+            "python",
+        ]);
+        assert!(cli.system.is_empty());
+        assert_eq!(cli.exclude_system, vec!["python"]);
+    }
+
+    #[test]
+    fn list_systems_flag() {
+        let cli = Cli::parse_from(["clean-builds", "--list-systems"]);
+        assert!(cli.list_systems);
+    }
+
+    #[test]
+    fn system_and_exclude_system_conflict() {
+        let result = Cli::try_parse_from([
+            "clean-builds",
+            "--system",
+            "cargo",
+            "--exclude-system",
+            "node",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,24 +109,14 @@ mod tests {
 
     #[test]
     fn system_flag() {
-        let cli = Cli::parse_from([
-            "clean-builds",
-            "--system",
-            "cargo",
-            "--system",
-            "node",
-        ]);
+        let cli = Cli::parse_from(["clean-builds", "--system", "cargo", "--system", "node"]);
         assert_eq!(cli.system, vec!["cargo", "node"]);
         assert!(cli.exclude_system.is_empty());
     }
 
     #[test]
     fn exclude_system_flag() {
-        let cli = Cli::parse_from([
-            "clean-builds",
-            "--exclude-system",
-            "python",
-        ]);
+        let cli = Cli::parse_from(["clean-builds", "--exclude-system", "python"]);
         assert!(cli.system.is_empty());
         assert_eq!(cli.exclude_system, vec!["python"]);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ use log::info;
 use clean_builds::cli::Cli;
 use clean_builds::delete::confirm_and_delete;
 use clean_builds::filter::ArtifactFilter;
-use clean_builds::output::{print_dry_run_footer, print_summary};
+use clean_builds::output::{print_dry_run_footer, print_summary, print_systems};
+use clean_builds::rules::{all_rules, filter_rules_by_system};
 use clean_builds::scanner::scan;
 use clean_builds::size::compute_sizes;
 
@@ -23,6 +24,24 @@ fn main() {
         .format_timestamp(None)
         .format_target(false)
         .init();
+
+    if cli.list_systems {
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        if let Err(e) = print_systems(&mut out) {
+            eprintln!("Error writing output: {e}");
+            process::exit(1);
+        }
+        return;
+    }
+
+    let rules = match filter_rules_by_system(all_rules(), &cli.system, &cli.exclude_system) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
 
     let root = match cli.path.canonicalize() {
         Ok(p) => p,
@@ -41,7 +60,7 @@ fn main() {
     };
 
     info!("Scanning {}", root.display());
-    let mut artifacts = scan(&root);
+    let mut artifacts = scan(&root, &rules);
 
     info!("Filtering artifacts");
     artifacts = filter.apply(&root, artifacts);

--- a/src/output.rs
+++ b/src/output.rs
@@ -109,6 +109,30 @@ pub fn print_summary(
     Ok(())
 }
 
+/// Print the table of available build system IDs.
+pub fn print_systems(out: &mut dyn Write) -> std::io::Result<()> {
+    let systems = crate::rules::system_ids();
+    let id_width = systems.iter().map(|(id, _)| id.len()).max().unwrap_or(2).max(2);
+    let name_width = systems
+        .iter()
+        .map(|(_, name)| name.len())
+        .max()
+        .unwrap_or(12)
+        .max(12);
+
+    writeln!(out, "{:<id_width$}  {:<name_width$}", "ID", "Build System")?;
+    writeln!(
+        out,
+        "{:<id_width$}  {:<name_width$}",
+        "-".repeat(id_width),
+        "-".repeat(name_width)
+    )?;
+    for (id, name) in &systems {
+        writeln!(out, "{:<id_width$}  {:<name_width$}", id, name)?;
+    }
+    Ok(())
+}
+
 /// Print the dry-run footer message.
 pub fn print_dry_run_footer(out: &mut dyn Write) -> std::io::Result<()> {
     writeln!(out)?;
@@ -179,5 +203,20 @@ mod tests {
         print_dry_run_footer(&mut buf).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("Run with --delete"));
+    }
+
+    #[test]
+    fn print_systems_shows_ids() {
+        let mut buf = Vec::new();
+        print_systems(&mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("ID"));
+        assert!(output.contains("Build System"));
+        assert!(output.contains("cargo"));
+        assert!(output.contains("Rust/Cargo"));
+        assert!(output.contains("node"));
+        assert!(output.contains("Node.js"));
+        assert!(output.contains("python"));
+        assert!(output.contains("Python"));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -112,7 +112,12 @@ pub fn print_summary(
 /// Print the table of available build system IDs.
 pub fn print_systems(out: &mut dyn Write) -> std::io::Result<()> {
     let systems = crate::rules::system_ids();
-    let id_width = systems.iter().map(|(id, _)| id.len()).max().unwrap_or(2).max(2);
+    let id_width = systems
+        .iter()
+        .map(|(id, _)| id.len())
+        .max()
+        .unwrap_or(2)
+        .max(2);
     let name_width = systems
         .iter()
         .map(|(_, name)| name.len())

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -372,8 +372,23 @@ mod tests {
     fn system_ids_covers_all_systems() {
         let ids = system_ids();
         let expected = [
-            "bundler", "cabal", "cargo", "cmake", "cocoapods", "composer", "dotnet", "flutter",
-            "gradle", "maven", "mix", "node", "python", "sbt", "spm", "stack", "zig",
+            "bundler",
+            "cabal",
+            "cargo",
+            "cmake",
+            "cocoapods",
+            "composer",
+            "dotnet",
+            "flutter",
+            "gradle",
+            "maven",
+            "mix",
+            "node",
+            "python",
+            "sbt",
+            "spm",
+            "stack",
+            "zig",
         ];
         let actual: Vec<&str> = ids.iter().map(|(id, _)| *id).collect();
         for id in &expected {
@@ -385,8 +400,7 @@ mod tests {
     #[test]
     fn filter_include_keeps_matching() {
         let rules = all_rules();
-        let filtered =
-            filter_rules_by_system(rules, &["cargo".to_string()], &[]).unwrap();
+        let filtered = filter_rules_by_system(rules, &["cargo".to_string()], &[]).unwrap();
         assert!(!filtered.is_empty());
         for r in &filtered {
             assert_eq!(r.rule.id, "cargo");
@@ -397,8 +411,7 @@ mod tests {
     fn filter_exclude_removes_matching() {
         let rules = all_rules();
         let total = rules.len();
-        let filtered =
-            filter_rules_by_system(rules, &[], &["python".to_string()]).unwrap();
+        let filtered = filter_rules_by_system(rules, &[], &["python".to_string()]).unwrap();
         assert!(filtered.len() < total);
         for r in &filtered {
             assert_ne!(r.rule.id, "python");
@@ -416,8 +429,7 @@ mod tests {
     #[test]
     fn filter_unknown_id_errors() {
         let rules = all_rules();
-        let result =
-            filter_rules_by_system(rules, &["nonexistent".to_string()], &[]);
+        let result = filter_rules_by_system(rules, &["nonexistent".to_string()], &[]);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("nonexistent"));
@@ -427,8 +439,7 @@ mod tests {
     #[test]
     fn filter_case_insensitive() {
         let rules = all_rules();
-        let filtered =
-            filter_rules_by_system(rules, &["CARGO".to_string()], &[]).unwrap();
+        let filtered = filter_rules_by_system(rules, &["CARGO".to_string()], &[]).unwrap();
         assert!(!filtered.is_empty());
         for r in &filtered {
             assert_eq!(r.rule.id, "cargo");
@@ -438,12 +449,8 @@ mod tests {
     #[test]
     fn filter_multiple_include() {
         let rules = all_rules();
-        let filtered = filter_rules_by_system(
-            rules,
-            &["cargo".to_string(), "node".to_string()],
-            &[],
-        )
-        .unwrap();
+        let filtered =
+            filter_rules_by_system(rules, &["cargo".to_string(), "node".to_string()], &[]).unwrap();
         let ids: HashSet<&str> = filtered.iter().map(|r| r.rule.id).collect();
         assert_eq!(ids.len(), 2);
         assert!(ids.contains("cargo"));

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use log::warn;
@@ -5,6 +6,8 @@ use log::warn;
 /// Describes a build artifact directory and how to identify it.
 #[derive(Debug, Clone)]
 pub struct ArtifactRule {
+    /// Short, CLI-friendly identifier for the build system (e.g., "cargo", "node").
+    pub id: &'static str,
     pub build_system: &'static str,
     pub artifact_dir: &'static str,
     pub marker: MarkerKind,
@@ -35,26 +38,35 @@ pub struct MatchableRule {
     pub dir_match: DirMatch,
 }
 
+/// Error from invalid system IDs in `--system` or `--exclude-system`.
+#[derive(thiserror::Error, Debug)]
+#[error("unknown build system: {id}\nValid systems: {valid}")]
+pub struct SystemFilterError {
+    id: String,
+    valid: String,
+}
+
 /// Returns the full set of artifact rules, ordered so that more specific markers
 /// come first (helps with disambiguation of `target/`, `build/`, etc.).
 pub fn all_rules() -> Vec<MatchableRule> {
     vec![
         // Java/Maven
-        mr("Java/Maven", "target", &["pom.xml"]),
+        mr("maven", "Java/Maven", "target", &["pom.xml"]),
         // Rust/Cargo
-        mr("Rust/Cargo", "target", &["Cargo.toml"]),
+        mr("cargo", "Rust/Cargo", "target", &["Cargo.toml"]),
         // Scala/SBT
-        mr("Scala/SBT", "target", &["build.sbt"]),
+        mr("sbt", "Scala/SBT", "target", &["build.sbt"]),
         // Node.js
-        mr("Node.js", "node_modules", &["package.json"]),
-        mr("Node.js", ".next", &["package.json"]),
-        mr("Node.js", ".nuxt", &["package.json"]),
-        mr("Node.js", ".output", &["package.json"]),
+        mr("node", "Node.js", "node_modules", &["package.json"]),
+        mr("node", "Node.js", ".next", &["package.json"]),
+        mr("node", "Node.js", ".nuxt", &["package.json"]),
+        mr("node", "Node.js", ".output", &["package.json"]),
         // Swift/SPM
-        mr("Swift/SPM", ".build", &["Package.swift"]),
+        mr("spm", "Swift/SPM", ".build", &["Package.swift"]),
         // Python -- no-marker variants
         MatchableRule {
             rule: ArtifactRule {
+                id: "python",
                 build_system: "Python",
                 artifact_dir: "__pycache__",
                 marker: MarkerKind::Always,
@@ -63,6 +75,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         MatchableRule {
             rule: ArtifactRule {
+                id: "python",
                 build_system: "Python",
                 artifact_dir: ".mypy_cache",
                 marker: MarkerKind::Always,
@@ -71,6 +84,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         MatchableRule {
             rule: ArtifactRule {
+                id: "python",
                 build_system: "Python",
                 artifact_dir: ".pytest_cache",
                 marker: MarkerKind::Always,
@@ -79,16 +93,19 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         // Python -- marker variants
         mr_multi(
+            "python",
             "Python",
             ".venv",
             &["pyproject.toml", "setup.py", "requirements.txt"],
         ),
         mr_multi(
+            "python",
             "Python",
             "venv",
             &["pyproject.toml", "setup.py", "requirements.txt"],
         ),
         mr_multi(
+            "python",
             "Python",
             ".tox",
             &["pyproject.toml", "setup.py", "requirements.txt"],
@@ -96,6 +113,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         // Python egg-info (suffix match)
         MatchableRule {
             rule: ArtifactRule {
+                id: "python",
                 build_system: "Python",
                 artifact_dir: "*.egg-info",
                 marker: MarkerKind::Files(&["pyproject.toml", "setup.py", "requirements.txt"]),
@@ -104,21 +122,24 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         // Android/Gradle
         mr_multi(
+            "gradle",
             "Android/Gradle",
             "build",
             &["build.gradle", "build.gradle.kts"],
         ),
         mr_multi(
+            "gradle",
             "Android/Gradle",
             ".gradle",
             &["build.gradle", "build.gradle.kts"],
         ),
         // C/C++/CMake
-        mr("C/C++/CMake", "build", &["CMakeLists.txt"]),
-        mr("C/C++/CMake", "CMakeFiles", &["CMakeLists.txt"]),
+        mr("cmake", "C/C++/CMake", "build", &["CMakeLists.txt"]),
+        mr("cmake", "C/C++/CMake", "CMakeFiles", &["CMakeLists.txt"]),
         // .NET/C#
         MatchableRule {
             rule: ArtifactRule {
+                id: "dotnet",
                 build_system: ".NET/C#",
                 artifact_dir: "bin",
                 marker: MarkerKind::GlobSuffix(".csproj"),
@@ -127,6 +148,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         MatchableRule {
             rule: ArtifactRule {
+                id: "dotnet",
                 build_system: ".NET/C#",
                 artifact_dir: "obj",
                 marker: MarkerKind::GlobSuffix(".csproj"),
@@ -136,6 +158,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         // .NET/C# -- .sln marker
         MatchableRule {
             rule: ArtifactRule {
+                id: "dotnet",
                 build_system: ".NET/C#",
                 artifact_dir: "bin",
                 marker: MarkerKind::GlobSuffix(".sln"),
@@ -144,6 +167,7 @@ pub fn all_rules() -> Vec<MatchableRule> {
         },
         MatchableRule {
             rule: ArtifactRule {
+                id: "dotnet",
                 build_system: ".NET/C#",
                 artifact_dir: "obj",
                 marker: MarkerKind::GlobSuffix(".sln"),
@@ -151,13 +175,14 @@ pub fn all_rules() -> Vec<MatchableRule> {
             dir_match: DirMatch::Exact("obj"),
         },
         // Elixir/Mix
-        mr("Elixir/Mix", "_build", &["mix.exs"]),
-        mr("Elixir/Mix", "deps", &["mix.exs"]),
+        mr("mix", "Elixir/Mix", "_build", &["mix.exs"]),
+        mr("mix", "Elixir/Mix", "deps", &["mix.exs"]),
         // Haskell/Stack
-        mr("Haskell/Stack", ".stack-work", &["stack.yaml"]),
+        mr("stack", "Haskell/Stack", ".stack-work", &["stack.yaml"]),
         // Haskell/Cabal
         MatchableRule {
             rule: ArtifactRule {
+                id: "cabal",
                 build_system: "Haskell/Cabal",
                 artifact_dir: "dist-newstyle",
                 marker: MarkerKind::GlobSuffix(".cabal"),
@@ -165,29 +190,91 @@ pub fn all_rules() -> Vec<MatchableRule> {
             dir_match: DirMatch::Exact("dist-newstyle"),
         },
         // Dart/Flutter
-        mr("Dart/Flutter", ".dart_tool", &["pubspec.yaml"]),
-        mr("Dart/Flutter", "build", &["pubspec.yaml"]),
+        mr("flutter", "Dart/Flutter", ".dart_tool", &["pubspec.yaml"]),
+        mr("flutter", "Dart/Flutter", "build", &["pubspec.yaml"]),
         // Zig
-        mr("Zig", "zig-out", &["build.zig"]),
-        mr("Zig", "zig-cache", &["build.zig"]),
+        mr("zig", "Zig", "zig-out", &["build.zig"]),
+        mr("zig", "Zig", "zig-cache", &["build.zig"]),
         // PHP/Composer
-        mr("PHP/Composer", "vendor", &["composer.json"]),
+        mr("composer", "PHP/Composer", "vendor", &["composer.json"]),
         // CocoaPods
-        mr("CocoaPods", "Pods", &["Podfile"]),
+        mr("cocoapods", "CocoaPods", "Pods", &["Podfile"]),
         // Ruby/Bundler -- special: matches `bundle` inside a `vendor/` directory.
         // The scanner checks the grandparent for `Gemfile`.
-        mr("Ruby/Bundler", "bundle", &["Gemfile"]),
+        mr("bundler", "Ruby/Bundler", "bundle", &["Gemfile"]),
     ]
+}
+
+/// Returns sorted, deduplicated `(id, display_name)` pairs for all build systems.
+pub fn system_ids() -> Vec<(&'static str, &'static str)> {
+    let mut seen = BTreeSet::new();
+    let mut result = Vec::new();
+    for r in all_rules() {
+        if seen.insert(r.rule.id) {
+            result.push((r.rule.id, r.rule.build_system));
+        }
+    }
+    result.sort_by_key(|(id, _)| *id);
+    result
+}
+
+/// Filter rules by system ID include/exclude lists.
+///
+/// When both slices are empty, returns all rules unchanged.
+/// IDs are matched case-insensitively.
+pub fn filter_rules_by_system(
+    rules: Vec<MatchableRule>,
+    include: &[String],
+    exclude: &[String],
+) -> Result<Vec<MatchableRule>, SystemFilterError> {
+    if include.is_empty() && exclude.is_empty() {
+        return Ok(rules);
+    }
+
+    let valid_ids: BTreeSet<&str> = rules.iter().map(|r| r.rule.id).collect();
+
+    // Validate and normalize IDs
+    let normalize = |ids: &[String]| -> Result<Vec<String>, SystemFilterError> {
+        ids.iter()
+            .map(|id| {
+                let lower = id.to_ascii_lowercase();
+                if valid_ids.contains(lower.as_str()) {
+                    Ok(lower)
+                } else {
+                    Err(SystemFilterError {
+                        id: id.clone(),
+                        valid: valid_ids.iter().copied().collect::<Vec<_>>().join(", "),
+                    })
+                }
+            })
+            .collect()
+    };
+
+    if !include.is_empty() {
+        let normalized = normalize(include)?;
+        Ok(rules
+            .into_iter()
+            .filter(|r| normalized.iter().any(|id| id == r.rule.id))
+            .collect())
+    } else {
+        let normalized = normalize(exclude)?;
+        Ok(rules
+            .into_iter()
+            .filter(|r| !normalized.iter().any(|id| id == r.rule.id))
+            .collect())
+    }
 }
 
 /// Shorthand for an exact-match rule with a single-file marker set.
 fn mr(
+    id: &'static str,
     build_system: &'static str,
     artifact_dir: &'static str,
     markers: &'static [&'static str],
 ) -> MatchableRule {
     MatchableRule {
         rule: ArtifactRule {
+            id,
             build_system,
             artifact_dir,
             marker: MarkerKind::Files(markers),
@@ -198,11 +285,12 @@ fn mr(
 
 /// Shorthand for an exact-match rule with multiple marker files.
 fn mr_multi(
+    id: &'static str,
     build_system: &'static str,
     artifact_dir: &'static str,
     markers: &'static [&'static str],
 ) -> MatchableRule {
-    mr(build_system, artifact_dir, markers)
+    mr(id, build_system, artifact_dir, markers)
 }
 
 /// Check if a parent directory contains any file matching the given marker.
@@ -235,6 +323,7 @@ pub fn matches_dir(dir_name: &str, dir_match: &DirMatch) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
     use std::fs;
     use tempfile::TempDir;
 
@@ -243,9 +332,122 @@ mod tests {
         let rules = all_rules();
         assert!(!rules.is_empty());
         for r in &rules {
+            assert!(!r.rule.id.is_empty());
             assert!(!r.rule.build_system.is_empty());
             assert!(!r.rule.artifact_dir.is_empty());
         }
+    }
+
+    #[test]
+    fn all_ids_are_lowercase() {
+        for r in all_rules() {
+            assert_eq!(
+                r.rule.id,
+                r.rule.id.to_ascii_lowercase(),
+                "ID '{}' is not lowercase",
+                r.rule.id
+            );
+        }
+    }
+
+    #[test]
+    fn system_ids_are_unique() {
+        let ids = system_ids();
+        let unique: HashSet<&str> = ids.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids.len(), unique.len(), "duplicate system IDs found");
+    }
+
+    #[test]
+    fn system_ids_sorted() {
+        let ids = system_ids();
+        let sorted: Vec<_> = {
+            let mut v = ids.clone();
+            v.sort_by_key(|(id, _)| *id);
+            v
+        };
+        assert_eq!(ids, sorted);
+    }
+
+    #[test]
+    fn system_ids_covers_all_systems() {
+        let ids = system_ids();
+        let expected = [
+            "bundler", "cabal", "cargo", "cmake", "cocoapods", "composer", "dotnet", "flutter",
+            "gradle", "maven", "mix", "node", "python", "sbt", "spm", "stack", "zig",
+        ];
+        let actual: Vec<&str> = ids.iter().map(|(id, _)| *id).collect();
+        for id in &expected {
+            assert!(actual.contains(id), "Missing system ID: {id}");
+        }
+        assert_eq!(actual.len(), expected.len());
+    }
+
+    #[test]
+    fn filter_include_keeps_matching() {
+        let rules = all_rules();
+        let filtered =
+            filter_rules_by_system(rules, &["cargo".to_string()], &[]).unwrap();
+        assert!(!filtered.is_empty());
+        for r in &filtered {
+            assert_eq!(r.rule.id, "cargo");
+        }
+    }
+
+    #[test]
+    fn filter_exclude_removes_matching() {
+        let rules = all_rules();
+        let total = rules.len();
+        let filtered =
+            filter_rules_by_system(rules, &[], &["python".to_string()]).unwrap();
+        assert!(filtered.len() < total);
+        for r in &filtered {
+            assert_ne!(r.rule.id, "python");
+        }
+    }
+
+    #[test]
+    fn filter_empty_returns_all() {
+        let rules = all_rules();
+        let total = rules.len();
+        let filtered = filter_rules_by_system(rules, &[], &[]).unwrap();
+        assert_eq!(filtered.len(), total);
+    }
+
+    #[test]
+    fn filter_unknown_id_errors() {
+        let rules = all_rules();
+        let result =
+            filter_rules_by_system(rules, &["nonexistent".to_string()], &[]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+        assert!(err.to_string().contains("cargo"));
+    }
+
+    #[test]
+    fn filter_case_insensitive() {
+        let rules = all_rules();
+        let filtered =
+            filter_rules_by_system(rules, &["CARGO".to_string()], &[]).unwrap();
+        assert!(!filtered.is_empty());
+        for r in &filtered {
+            assert_eq!(r.rule.id, "cargo");
+        }
+    }
+
+    #[test]
+    fn filter_multiple_include() {
+        let rules = all_rules();
+        let filtered = filter_rules_by_system(
+            rules,
+            &["cargo".to_string(), "node".to_string()],
+            &[],
+        )
+        .unwrap();
+        let ids: HashSet<&str> = filtered.iter().map(|r| r.rule.id).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("cargo"));
+        assert!(ids.contains("node"));
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use jwalk::WalkDir;
 use log::{debug, warn};
 
-use crate::rules::{MatchableRule, all_rules, has_marker, matches_dir};
+use crate::rules::{MatchableRule, has_marker, matches_dir};
 
 /// A detected build artifact.
 #[derive(Debug, Clone)]
@@ -20,8 +20,11 @@ pub struct Artifact {
 ///
 /// Uses jwalk's `process_read_dir` callback to match artifacts inline during
 /// traversal and prune matched directories so their children are never visited.
-pub fn scan(root: &Path) -> Vec<Artifact> {
-    let rules = all_rules();
+///
+/// The caller provides the set of rules to match against, allowing pre-filtering
+/// by build system before any filesystem work is done.
+pub fn scan(root: &Path, rules: &[MatchableRule]) -> Vec<Artifact> {
+    let rules = rules.to_vec();
     let artifacts = Arc::new(Mutex::new(Vec::new()));
     let artifacts_ref = Arc::clone(&artifacts);
 
@@ -122,6 +125,7 @@ fn try_match(path: &Path, dir_name: &str, rules: &[MatchableRule]) -> Option<Art
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rules::all_rules;
     use std::collections::HashSet;
     use std::fs;
     use tempfile::TempDir;
@@ -141,7 +145,7 @@ mod tests {
     fn detects_rust_target() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "Cargo.toml", "target");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Rust/Cargo");
         assert_eq!(artifacts[0].artifact_dir, "target");
@@ -151,7 +155,7 @@ mod tests {
     fn detects_node_modules() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "package.json", "node_modules");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Node.js");
     }
@@ -160,7 +164,7 @@ mod tests {
     fn detects_maven_target() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "pom.xml", "target");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Java/Maven");
     }
@@ -171,7 +175,7 @@ mod tests {
         let pycache = tmp.path().join("some_dir").join("__pycache__");
         fs::create_dir_all(&pycache).unwrap();
         fs::write(pycache.join("module.pyc"), "").unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Python");
         assert_eq!(artifacts[0].artifact_dir, "__pycache__");
@@ -184,7 +188,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         fs::write(project.join("pyproject.toml"), "").unwrap();
         fs::create_dir_all(project.join(".venv")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Python");
         assert_eq!(artifacts[0].artifact_dir, ".venv");
@@ -195,7 +199,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let project = tmp.path().join("random");
         fs::create_dir_all(project.join(".venv")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert!(artifacts.is_empty());
     }
 
@@ -203,7 +207,7 @@ mod tests {
     fn detects_gradle_build() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "build.gradle", "build");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Android/Gradle");
     }
@@ -212,7 +216,7 @@ mod tests {
     fn detects_cmake_build() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "CMakeLists.txt", "build");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "C/C++/CMake");
     }
@@ -225,7 +229,7 @@ mod tests {
         fs::write(project.join("MyApp.csproj"), "").unwrap();
         fs::create_dir_all(project.join("bin")).unwrap();
         fs::create_dir_all(project.join("obj")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 2);
         let systems: Vec<&str> = artifacts.iter().map(|a| a.build_system).collect();
         assert!(systems.iter().all(|s| *s == ".NET/C#"));
@@ -238,7 +242,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         fs::write(project.join("setup.py"), "").unwrap();
         fs::create_dir_all(project.join("mylib.egg-info")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Python");
     }
@@ -248,7 +252,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let git = tmp.path().join(".git");
         fs::create_dir_all(&git).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert!(artifacts.is_empty());
     }
 
@@ -258,7 +262,7 @@ mod tests {
         // build/ without any marker files should not match
         let project = tmp.path().join("generic");
         fs::create_dir_all(project.join("build")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert!(artifacts.is_empty());
     }
 
@@ -277,7 +281,7 @@ mod tests {
         fs::write(nested.join("package.json"), "").unwrap();
         fs::create_dir_all(nested.join("node_modules")).unwrap();
 
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         // Should only detect the outer node_modules, not the nested one
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].path, nm);
@@ -299,7 +303,7 @@ mod tests {
         fs::write(node_proj.join("package.json"), "").unwrap();
         fs::create_dir_all(node_proj.join("node_modules")).unwrap();
 
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 2);
         let systems: HashSet<&str> = artifacts.iter().map(|a| a.build_system).collect();
         assert!(systems.contains("Rust/Cargo"));
@@ -313,7 +317,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         fs::write(project.join("Gemfile"), "").unwrap();
         fs::create_dir_all(project.join("vendor").join("bundle")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Ruby/Bundler");
     }
@@ -326,7 +330,7 @@ mod tests {
         fs::write(project.join("Gemfile"), "").unwrap();
         // Just vendor/ without bundle/ inside
         fs::create_dir_all(project.join("vendor")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert!(artifacts.is_empty());
     }
 
@@ -334,7 +338,7 @@ mod tests {
     fn detects_swift_spm_build() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "Package.swift", ".build");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "Swift/SPM");
     }
@@ -347,7 +351,7 @@ mod tests {
         fs::write(project.join("mix.exs"), "").unwrap();
         fs::create_dir_all(project.join("_build")).unwrap();
         fs::create_dir_all(project.join("deps")).unwrap();
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 2);
         assert!(artifacts.iter().all(|a| a.build_system == "Elixir/Mix"));
     }
@@ -356,7 +360,7 @@ mod tests {
     fn detects_cocoapods() {
         let tmp = TempDir::new().unwrap();
         set_up_project(&tmp, "Podfile", "Pods");
-        let artifacts = scan(tmp.path());
+        let artifacts = scan(tmp.path(), &all_rules());
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].build_system, "CocoaPods");
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,6 +17,15 @@ fn set_up_rust_project(tmp: &TempDir) {
     fs::write(target.join("debug").join("app"), "binary data").unwrap();
 }
 
+fn set_up_python_project(tmp: &TempDir) {
+    let project = tmp.path().join("my-python-app");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(project.join("pyproject.toml"), "").unwrap();
+    let pycache = project.join("__pycache__");
+    fs::create_dir_all(&pycache).unwrap();
+    fs::write(pycache.join("module.pyc"), "bytecode").unwrap();
+}
+
 fn set_up_node_project(tmp: &TempDir) {
     let project = tmp.path().join("my-node-app");
     fs::create_dir_all(&project).unwrap();
@@ -292,4 +301,143 @@ fn default_does_not_show_debug_log() {
         .assert()
         .success()
         .stderr(predicate::str::contains("Found artifact").not());
+}
+
+// -- System filter integration tests --
+
+#[test]
+fn system_filters_to_one_system() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+    set_up_node_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--system")
+        .arg("cargo")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust/Cargo"))
+        .stdout(predicate::str::contains("Node.js").not());
+}
+
+#[test]
+fn system_multiple() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+    set_up_node_project(&tmp);
+    set_up_python_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--system")
+        .arg("cargo")
+        .arg("--system")
+        .arg("node")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust/Cargo"))
+        .stdout(predicate::str::contains("Node.js"))
+        .stdout(predicate::str::contains("Python").not());
+}
+
+#[test]
+fn exclude_system() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+    set_up_node_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--exclude-system")
+        .arg("node")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust/Cargo"))
+        .stdout(predicate::str::contains("Node.js").not());
+}
+
+#[test]
+fn invalid_system_errors() {
+    let tmp = TempDir::new().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--system")
+        .arg("nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown build system"));
+}
+
+#[test]
+fn system_and_exclude_system_conflict() {
+    cmd()
+        .arg("--system")
+        .arg("cargo")
+        .arg("--exclude-system")
+        .arg("node")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn list_systems_shows_table() {
+    cmd()
+        .arg("--list-systems")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cargo"))
+        .stdout(predicate::str::contains("node"))
+        .stdout(predicate::str::contains("python"))
+        .stdout(predicate::str::contains("Rust/Cargo"))
+        .stdout(predicate::str::contains("ID"));
+}
+
+#[test]
+fn list_systems_works_without_path() {
+    // --list-systems should work even without a valid path argument
+    cmd()
+        .arg("--list-systems")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cargo"));
+}
+
+#[test]
+fn system_combined_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    set_up_node_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--system")
+        .arg("node")
+        .arg("--exclude")
+        .arg("my-node*")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No build artifacts found."));
+}
+
+#[test]
+fn delete_with_system_filter() {
+    let tmp = TempDir::new().unwrap();
+    set_up_rust_project(&tmp);
+    set_up_node_project(&tmp);
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--system")
+        .arg("node")
+        .arg("--delete")
+        .arg("--yes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Deleted 1 of 1"));
+
+    // node_modules should be deleted
+    assert!(!tmp.path().join("my-node-app").join("node_modules").exists());
+    // Rust target should still exist
+    assert!(tmp.path().join("my-rust-app").join("target").exists());
 }


### PR DESCRIPTION
Closes #7

## Summary

- Add `--system <ID>` and `--exclude-system <ID>` flags to filter artifacts by build system identity (e.g., `--system cargo --system node`)
- Add `--list-systems` flag to display available system IDs
- Each build system gets a short CLI-friendly ID (`cargo`, `node`, `python`, etc.) via a new `id` field on `ArtifactRule`
- System filtering happens before scanning to avoid unnecessary filesystem work
- Invalid system IDs produce a hard error listing valid options; IDs are matched case-insensitively

## Test plan

- [x] All 79 existing unit tests pass
- [x] 9 new integration tests for system filtering (include, exclude, multiple, conflict, list, combined with glob, delete)
- [x] New unit tests for ID uniqueness, lowercase validation, include/exclude filtering, case-insensitivity, error messages
- [x] `cargo run -- --list-systems` displays the systems table
- [x] `--system` and `--exclude-system` conflict produces clap error